### PR TITLE
Add multiarch docker

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,6 +38,12 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+            
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+    
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -50,6 +56,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This pull request adds support for multiarch docker by setting up QEMU and Docker Buildx. It also updates the build-push-action to include platforms for both linux/amd64 and linux/arm64.

This should allow running this on cheaper ARM servers and M1+ Macs.

See https://docs.docker.com/build/ci/github-actions/multi-platform/